### PR TITLE
Props type naming suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ $ npm install proptypes-to-ts-declarations
 Using it:
 
 ```javascript
-const propTypesToTS = require('proptypes-to-ts-declarations');
+const propTypesToTS = require("proptypes-to-ts-declarations");
 
-propTypesToTS(
-  'my-library',
-  './src/components/**/*.js',
-  './index.d.ts');
+propTypesToTS("my-library", "./src/components/**/*.js", "./index.d.ts");
 ```
 
 ## Example
@@ -45,19 +42,14 @@ MyComponent.propTypes = {
 declare module "my-library" {
   import * as React from "react";
 
-  type timeEnum =
-    | "default"
-    | "information"
-    | "success"
-    | "warning"
-    | "danger";
+  type timeEnum = "default" | "information" | "success" | "warning" | "danger";
 
-  export interface my_component_props {
+  export interface MyComponentProps {
     className?: string;
     time: timeEnum;
     name: string;
   }
 
-  export const MyComponent: React.ComponentClass<my_component_props>;
+  export const MyComponent: React.ComponentClass<MyComponentProps>;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ declare module "my-library" {
   import * as React from "react";
 
   type timeEnum = 
-    | "default" 
-    | "information" 
-    | "success" 
-    | "warning" 
+    | "default"
+    | "information"
+    | "success"
+    | "warning"
     | "danger";
 
   export interface MyComponentProps {

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ $ npm install proptypes-to-ts-declarations
 Using it:
 
 ```javascript
-const propTypesToTS = require("proptypes-to-ts-declarations");
+const propTypesToTS = require('proptypes-to-ts-declarations');
 
-propTypesToTS("my-library", "./src/components/**/*.js", "./index.d.ts");
+propTypesToTS('my-library', './src/components/**/*.js', './index.d.ts');
 ```
 
 ## Example
@@ -42,7 +42,12 @@ MyComponent.propTypes = {
 declare module "my-library" {
   import * as React from "react";
 
-  type timeEnum = "default" | "information" | "success" | "warning" | "danger";
+  type timeEnum = 
+    | "default" 
+    | "information" 
+    | "success" 
+    | "warning" 
+    | "danger";
 
   export interface MyComponentProps {
     className?: string;

--- a/src/resolvers/propsNameResolver.js
+++ b/src/resolvers/propsNameResolver.js
@@ -1,3 +1,3 @@
 const _ = require('lodash');
 
-module.exports = component => _.snakeCase(`${component.displayName.toLowerCase()}Props`);
+module.exports = component => `${_.startCase(component.displayName).replace(/\s/g, '')}Props`;

--- a/test/builder.test.js
+++ b/test/builder.test.js
@@ -49,7 +49,7 @@ describe('builder', () => {
       .next(Strategies.interfaceStrategy)
       .end();
 
-    expect(result).to.equal('\n\ntype componentEnumEnum = \"default\";\n   export const Component: React.ComponentClass<component_props>;\n\n  interface component_props {\n     string?: string\n func?(): void\n\n  /**\n   * prop comment\n  */\n enum?: componentEnumEnum\n  }\n');
+    expect(result).to.equal('\n\ntype componentEnumEnum = \"default\";\n   export const Component: React.ComponentClass<ComponentProps>;\n\n  interface ComponentProps {\n     string?: string\n func?(): void\n\n  /**\n   * prop comment\n  */\n enum?: componentEnumEnum\n  }\n');
   });
 
   describe('strategies', () => {
@@ -171,7 +171,7 @@ describe('builder', () => {
           tsTypeResolver
         });
 
-        expect(interface).to.equal('\n  interface component_props {\n     string?: string\n func?(): void\n\n  /**\n   * prop comment\n  */\n enum?: componentEnumEnum\n  }\n');
+        expect(interface).to.equal('\n  interface ComponentProps {\n     string?: string\n func?(): void\n\n  /**\n   * prop comment\n  */\n enum?: componentEnumEnum\n  }\n');
       });
     })
 
@@ -197,7 +197,7 @@ describe('builder', () => {
           propsNameResolver
         });
 
-        expect(header).to.equal('\n   export const Component: React.ComponentClass<component_props>;\n');
+        expect(header).to.equal('\n   export const Component: React.ComponentClass<ComponentProps>;\n');
       });
     });
   });

--- a/test/resolvers.test.js
+++ b/test/resolvers.test.js
@@ -21,7 +21,12 @@ describe('resolvers', () => {
 
   it('should correctly resolve propsName', () => {
     const propsName = propsNameResolver({ displayName: 'component' });
-    expect(propsName).to.equal('component_props');
+    expect(propsName).to.equal('ComponentProps');
+  });
+
+  it('should correctly resolve multi-word component propsName', () => {
+    const propsName = propsNameResolver({ displayName: 'myComponent' });
+    expect(propsName).to.equal('MyComponentProps');
   });
 
   it('should correctly resolve ts type', () => {


### PR DESCRIPTION
Proposal to change `my_component_props` to `MyComponentProps`. As I saw it, that naming convention is more used than the first one. Let me know what you think :)